### PR TITLE
Noindent filter feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.py[cod]
+test/

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ The author thanks …
 Sollen sukzessive Absätze nicht eingerückt werden (was aufgrund des fehlenden Abstands zwischen den Paragraphen nur in Ausnahmefällen sinnvoll ist - lieber eine Liste verwenden), kann der Abschnitt mit `noindent` ausgezeichnet werden.
 
 ```markdown
-::: noindent
 
 ## A.  Standard Borrowings
 
@@ -163,7 +162,6 @@ Sollen sukzessive Absätze nicht eingerückt werden (was aufgrund des fehlenden 
 Wenn `noparnums` mit `noindent` kombiniert werden soll (was im obigen Beispiel sinnvoll ist), müssen die Klassen in eckigen Klammern eingefügt werden (**der `.` vor den Namen ist hier unbedingt notwendig**, siehe auch [pandoc Documentation `fenced_divs`](https://pandoc.org/MANUAL.html#extension-fenced_divs)).
 
 ```markdown
-::: noindent
 
 ## A.  Standard Borrowings
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,50 @@ The author thanks …
 :::
 ```
 
+Sollen sukzessive Absätze nicht eingerückt werden (was aufgrund des fehlenden Abstands zwischen den Paragraphen nur in Ausnahmefällen sinnvoll ist - lieber eine Liste verwenden), kann der Abschnitt mit `noindent` ausgezeichnet werden.
+
+```markdown
+::: noindent
+
+## A.  Standard Borrowings
+
+::: noindent
+
+*’’c’r(’)y* – *ācārya* (B, G, R) 2. b. 2. f.
+
+*’’kš’r* – *akṣara* (?, R) 2. q.
+
+*’’m(’)wkp’š* – *Amoghapāśa* (L, P) 2. a; 2. i.IL
+
+*’’n’k’my* – *anāgāmin*, nom. *anagamī* (R) 2. u. HL
+
+*’’n’nt* – *Ānanda* (MK, L, P) 2. q., n. 31
+
+:::
+```
+
+Wenn `noparnums` mit `noindent` kombiniert werden soll (was im obigen Beispiel sinnvoll ist), müssen die Klassen in eckigen Klammern eingefügt werden (**der `.` vor den Namen ist hier unbedingt notwendig**, siehe auch [pandoc Documentation `fenced_divs`](https://pandoc.org/MANUAL.html#extension-fenced_divs)).
+
+```markdown
+::: noindent
+
+## A.  Standard Borrowings
+
+::: { .noindent .noparnums }
+
+*’’c’r(’)y* – *ācārya* (B, G, R) 2. b. 2. f.
+
+*’’kš’r* – *akṣara* (?, R) 2. q.
+
+*’’m(’)wkp’š* – *Amoghapāśa* (L, P) 2. a; 2. i.IL
+
+*’’n’k’my* – *anāgāmin*, nom. *anagamī* (R) 2. u. HL
+
+*’’n’nt* – *Ānanda* (MK, L, P) 2. q., n. 31
+
+:::
+```
+
 ### Zitate
 
 Blockzitate stellen in pandoc immer einen eigenen Absatz dar. Daher ist es nicht ohne weiteres möglich, Blockzitate zu definieren, die Teil des umgebenden Absatzes sind. Es ist aber möglich, die folgende Einrückung im PDF zu unterdrücken:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Sollen sukzessive Absätze nicht eingerückt werden (was aufgrund des fehlenden 
 :::
 ```
 
-Wenn `noparnums` mit `noindent` kombiniert werden soll (was im obigen Beispiel sinnvoll ist), müssen die Klassen in eckigen Klammern eingefügt werden (**der `.` vor den Namen ist hier unbedingt notwendig**, siehe auch [pandoc Documentation `fenced_divs`](https://pandoc.org/MANUAL.html#extension-fenced_divs)).
+Wenn `noparnums` mit `noindent` kombiniert werden soll (was im obigen Beispiel sinnvoll ist), müssen die Klassen in geschweiften Klammern eingefügt werden (**der `.` vor den Namen ist hier unbedingt notwendig**, siehe auch [pandoc Documentation `fenced_divs`](https://pandoc.org/MANUAL.html#extension-fenced_divs)).
 
 ```markdown
 

--- a/compile_md2pdf.sh
+++ b/compile_md2pdf.sh
@@ -19,6 +19,7 @@ function build_tex {
         --defaults "defaults/common.yaml" \
         --defaults "defaults/latex.yaml" \
         --resource-path ".:$BASEPATH" \
+        --filter "filters/noindent.py" \
     && echo "done." \
     || echo "error!"
 

--- a/filters/noindent.py
+++ b/filters/noindent.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-A pandoc filter that places a \\noindent before every paragraph (this might be useful in case there are many short paragraphs and you don't want to use a list)
+A pandoc filter that places a \noindent before every paragraph; this might be useful in the rare case when you have many short paragraphs but you don't want to use a list
 """
 
 from panflute import *

--- a/filters/noindent.py
+++ b/filters/noindent.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+"""
+A pandoc filter that places a \\noindent before every paragraph (this might be useful in case there are many short paragraphs and you don't want to use a list)
+"""
+
+from panflute import *
+
+def latex(s):
+    return RawInline(s, format='latex')
+
+def no_indent_paras(elem, doc):
+    if isinstance(elem, Para):
+        if isinstance(elem.parent, Div) and 'noindent' in elem.parent.classes:
+            if doc.format == "latex":
+                return Para(latex(r"\noindent"), Space, *elem.content)
+
+def main(doc=None):
+    return run_filter(no_indent_paras, doc=doc)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
See also README.md for usage of `noindent`.

- [x] added noindent.py filter to `filters` folder
- [x] added `--filter filters/noindent.py` argument to `compile_md2pdf.sh` (maybe there is a better solution?)
- [x] added description of `noindent` and combining `noindent`  with `noparnums` to `README.md`
- [x] added stuff to `.gitignore` (due to local `test` folder)
- [ ] I did several tests, among others with the article I wrote this filter for, and everything seems to be fine; however, chances remain that this filter might break the internet  